### PR TITLE
Novel 도메인 클래스 추가 및 소설 등록 코드 작성

### DIFF
--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
     NOT_VALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_003", "비밀번호를 다시 확인해주세요."),
     ALREADY_EXIST_USERNAME(HttpStatus.BAD_REQUEST, "MEMBER_004", "이미 존재하는 회원 아이디입니다."),
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_005", "이미 존재하는 회원 닉네임입니다."),
+
+    NOT_VALID_GENRE(HttpStatus.BAD_REQUEST, "NOVEL_001", "유효하지 않은 장르입니다."),
+    NOT_VALID_SERIALIZED_STATUS(HttpStatus.BAD_REQUEST, "NOVEL_002", "유효하지 않은 연재 상태입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
+++ b/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
@@ -1,0 +1,27 @@
+package com.numble.webnovelservice.novel.controller;
+
+import com.numble.webnovelservice.common.response.ResponseMessage;
+import com.numble.webnovelservice.novel.dto.request.NovelRegisterRequest;
+import com.numble.webnovelservice.novel.service.NovelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+
+    @PostMapping
+    public ResponseEntity<ResponseMessage<Void>> registerNovel(@RequestBody NovelRegisterRequest request){
+        novelService.registerNovel(request);
+        return new ResponseEntity<>(new ResponseMessage<>("소설 등록 성공",null), HttpStatus.CREATED);
+
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/novel/dto/request/NovelRegisterRequest.java
+++ b/src/main/java/com/numble/webnovelservice/novel/dto/request/NovelRegisterRequest.java
@@ -1,0 +1,37 @@
+package com.numble.webnovelservice.novel.dto.request;
+
+import com.numble.webnovelservice.novel.entity.Genre;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.entity.SerializedStatus;
+import lombok.Getter;
+
+@Getter
+public class NovelRegisterRequest {
+
+    private String title;
+
+    private String description;
+
+    private String author;
+
+    private String genre;
+
+    private String serializedStatus;
+
+    private String coverImage;
+
+    public Novel toNovel(){
+        Genre genreEnum = Genre.fromKoreanName(genre);
+        SerializedStatus serializedStatusEnum = SerializedStatus.fromKoreanName(serializedStatus);
+
+        return Novel.builder()
+                .title(title)
+                .description(description)
+                .author(author)
+                .genre(genreEnum)
+                .serializedStatus(serializedStatusEnum)
+                .coverImage(coverImage)
+                .totalViewCount(0)
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/novel/entity/Genre.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/Genre.java
@@ -1,0 +1,33 @@
+package com.numble.webnovelservice.novel.entity;
+
+import com.numble.webnovelservice.common.exception.WebNovelServiceException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_VALID_GENRE;
+
+@Getter
+@AllArgsConstructor
+public enum Genre {
+
+    COMEDY("코미디"),
+    DRAMA("드라마"),
+    FANTASY("판타지"),
+    ROMANCE("로맨스"),
+    SCIENCE_FICTION("SF"),
+    ;
+
+    private final String koreanName;
+
+    public static Genre fromKoreanName(String genre) {
+
+        return switch (genre) {
+            case "코미디" -> COMEDY;
+            case "드라마" -> DRAMA;
+            case "판타지" -> FANTASY;
+            case "로맨스" -> ROMANCE;
+            case "SF" -> SCIENCE_FICTION;
+            default -> throw new WebNovelServiceException(NOT_VALID_GENRE);
+        };
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
@@ -1,0 +1,66 @@
+package com.numble.webnovelservice.novel.entity;
+
+import com.numble.webnovelservice.util.time.Timestamped;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Novel extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="novel_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Genre genre;
+
+    @Column(nullable = false)
+    private String coverImage;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SerializedStatus serializedStatus;
+
+    @Column(nullable = false)
+    private Integer totalViewCount;
+
+    @Column
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Novel(Long id, String title, String description, String author, Genre genre, String coverImage, SerializedStatus serializedStatus, Integer totalViewCount, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.author = author;
+        this.genre = genre;
+        this.coverImage = coverImage;
+        this.serializedStatus = serializedStatus;
+        this.totalViewCount = totalViewCount;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/novel/entity/SerializedStatus.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/SerializedStatus.java
@@ -1,0 +1,29 @@
+package com.numble.webnovelservice.novel.entity;
+
+import com.numble.webnovelservice.common.exception.WebNovelServiceException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_VALID_SERIALIZED_STATUS;
+
+@Getter
+@AllArgsConstructor
+public enum SerializedStatus {
+
+    SERIALIZING("연재 중"),
+    PAUSED("휴재"),
+    FINISHED("연재 완료"),
+    ;
+
+    private final String koreanName;
+
+    public static SerializedStatus fromKoreanName(String serializedStatus) {
+
+        return switch (serializedStatus) {
+            case "연재 중" -> SERIALIZING;
+            case "휴재" -> PAUSED;
+            case "연재 완료" -> FINISHED;
+            default -> throw new WebNovelServiceException(NOT_VALID_SERIALIZED_STATUS);
+        };
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/novel/repository/NovelRepository.java
+++ b/src/main/java/com/numble/webnovelservice/novel/repository/NovelRepository.java
@@ -1,0 +1,7 @@
+package com.numble.webnovelservice.novel.repository;
+
+import com.numble.webnovelservice.novel.entity.Novel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+}

--- a/src/main/java/com/numble/webnovelservice/novel/service/NovelService.java
+++ b/src/main/java/com/numble/webnovelservice/novel/service/NovelService.java
@@ -1,0 +1,22 @@
+package com.numble.webnovelservice.novel.service;
+
+import com.numble.webnovelservice.novel.dto.request.NovelRegisterRequest;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.repository.NovelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    private final NovelRepository novelRepository;
+
+    @Transactional
+    public void registerNovel(NovelRegisterRequest request){
+
+        Novel novel = request.toNovel();
+        novelRepository.save(novel);
+    }
+}


### PR DESCRIPTION
### Novel 도메인 클래스 추가 및 소설 등록 코드 작성
**Novel 클래스 추가 및 코드 작성**

**Genre 이넘 추가 및 코드 작성**
- `fromKoreanName()`은 request에서 한국어로 요청받은 status를 enum으로 바꿔주는 메서드입니다.
</br>

**SerializedStatus 이넘 추가 및 코드 작성**
- `fromKoreanName()`은 request에서 한국어로 요청받은 status를 enum으로 바꿔주는 메서드입니다.
</br>

**NovelController 클래스 추가 및 소설 등록 코드 작성**

**NovelRegisterRequest 클래스 추가 및 코드 작성**

**NovelController 클래스 추가**

**NovelService 클래스 추가 및 소설 등록 코드 작성**

**ErrorCode 코드 작성**
- 유효하지 않는 장르를 입력할 경우 반환하는 에러코드 추가
- 유효하지 않는 연재상태를 입력할 경우 반환하는 에러코드 추가