### PR TITLE
소설 정보 수정 코드 작성

### DIFF
--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     NOT_VALID_GENRE(HttpStatus.BAD_REQUEST, "NOVEL_001", "유효하지 않은 장르입니다."),
     NOT_VALID_SERIALIZED_STATUS(HttpStatus.BAD_REQUEST, "NOVEL_002", "유효하지 않은 연재 상태입니다."),
+    NOT_FOUND_NOVEL(HttpStatus.NOT_FOUND, "NOVEL_003", "찾을 수 없는 소설입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
+++ b/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
@@ -2,10 +2,13 @@ package com.numble.webnovelservice.novel.controller;
 
 import com.numble.webnovelservice.common.response.ResponseMessage;
 import com.numble.webnovelservice.novel.dto.request.NovelRegisterRequest;
+import com.numble.webnovelservice.novel.dto.request.NovelUpdateInfoRequest;
 import com.numble.webnovelservice.novel.service.NovelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +25,11 @@ public class NovelController {
     public ResponseEntity<ResponseMessage<Void>> registerNovel(@RequestBody NovelRegisterRequest request){
         novelService.registerNovel(request);
         return new ResponseEntity<>(new ResponseMessage<>("소설 등록 성공",null), HttpStatus.CREATED);
+    }
 
+    @PatchMapping("/{novelId}")
+    public ResponseEntity<ResponseMessage<Void>> updateNovelInfo(@PathVariable Long novelId, @RequestBody NovelUpdateInfoRequest request){
+        novelService.updateNovelInfo(novelId, request);
+        return new ResponseEntity<>(new ResponseMessage<>("소설 정보 수정 성공",null), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/numble/webnovelservice/novel/dto/request/NovelUpdateInfoRequest.java
+++ b/src/main/java/com/numble/webnovelservice/novel/dto/request/NovelUpdateInfoRequest.java
@@ -1,0 +1,13 @@
+package com.numble.webnovelservice.novel.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class NovelUpdateInfoRequest {
+
+    private String description;
+
+    private String coverImage;
+
+    private String serializedStatus;
+}

--- a/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
@@ -1,5 +1,6 @@
 package com.numble.webnovelservice.novel.entity;
 
+import com.numble.webnovelservice.novel.dto.request.NovelUpdateInfoRequest;
 import com.numble.webnovelservice.util.time.Timestamped;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -63,4 +64,13 @@ public class Novel extends Timestamped {
         this.totalViewCount = totalViewCount;
         this.updatedAt = updatedAt;
     }
+
+    public void updateInfo(NovelUpdateInfoRequest request){
+        SerializedStatus serializedStatusEnum = SerializedStatus.fromKoreanName(request.getSerializedStatus());
+
+        this.description = request.getDescription();
+        this.coverImage = request.getCoverImage();
+        this.serializedStatus = serializedStatusEnum;
+    }
+
 }

--- a/src/main/java/com/numble/webnovelservice/novel/service/NovelService.java
+++ b/src/main/java/com/numble/webnovelservice/novel/service/NovelService.java
@@ -1,11 +1,15 @@
 package com.numble.webnovelservice.novel.service;
 
+import com.numble.webnovelservice.common.exception.WebNovelServiceException;
 import com.numble.webnovelservice.novel.dto.request.NovelRegisterRequest;
+import com.numble.webnovelservice.novel.dto.request.NovelUpdateInfoRequest;
 import com.numble.webnovelservice.novel.entity.Novel;
 import com.numble.webnovelservice.novel.repository.NovelRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_NOVEL;
 
 @Service
 @RequiredArgsConstructor
@@ -19,4 +23,15 @@ public class NovelService {
         Novel novel = request.toNovel();
         novelRepository.save(novel);
     }
+
+    @Transactional
+    public void updateNovelInfo(Long novelId, NovelUpdateInfoRequest request){
+
+        Novel novel = novelRepository.findById(novelId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_NOVEL));
+
+        novel.updateInfo(request);
+    }
+
+
 }


### PR DESCRIPTION
### 소설 정보 수정 코드 작성
**NovelController 소설 정보 수정 코드 작성** 

**NovelService 소설 정보 수정 코드 작성** 

**Novel 소설 정보 수정 시 필요한 Entity 메서드 추가**
- `updateInfo()`는 request에서 받은 한국어 연재상태를 SerializedStatus.fromKoreanName()를 이용해 Enum으로 바꿉니다.

**NovelUpdateInfoRequest 클래스 추가 및 코드 작성**

**ErrorCode 코드 작성**
- 소설을 못찾을 경우 반환하는 Error 코드 `NOT_FOUND_NOVEL` 추가 