### PR TITLE
거래 도메인 관련 클래스 추가 및 코드 작성 / 포인트 거래 기록 조회 코드 작성

### DIFF
--- a/src/main/java/com/numble/webnovelservice/transaction/controller/PointTransactionController.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/controller/PointTransactionController.java
@@ -1,0 +1,27 @@
+package com.numble.webnovelservice.transaction.controller;
+
+import com.numble.webnovelservice.common.response.ResponseMessage;
+import com.numble.webnovelservice.transaction.dto.response.PointTransactionResponseList;
+import com.numble.webnovelservice.transaction.service.PointTransactionService;
+import com.numble.webnovelservice.util.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/point-transactions")
+public class PointTransactionController {
+
+    private final PointTransactionService pointTransactionService;
+
+    @GetMapping
+    public ResponseEntity<ResponseMessage<PointTransactionResponseList>> retrieveCurrentMemberPointTransactions(UserDetailsImpl userDetails){
+
+        PointTransactionResponseList response = pointTransactionService.retrieveCurrentMemberPointTransactions(userDetails.getMember());
+        return new ResponseEntity<>(new ResponseMessage<>("포인트 거래 기록 조회 성공", response), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/dto/response/PointTransactionResponse.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/dto/response/PointTransactionResponse.java
@@ -1,0 +1,45 @@
+package com.numble.webnovelservice.transaction.dto.response;
+
+import com.numble.webnovelservice.transaction.entity.PointTransaction;
+import com.numble.webnovelservice.transaction.entity.Type;
+import com.numble.webnovelservice.util.time.TimeConverter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public class PointTransactionResponse {
+
+    private Long pointTransactionId;
+
+    private String type;
+
+    private Integer amount;
+
+    private String createdAt;
+
+    @Builder
+    public PointTransactionResponse(Long pointTransactionId, String type, Integer amount, String createdAt) {
+
+        this.pointTransactionId = pointTransactionId;
+        this.type = type;
+        this.amount = amount;
+        this.createdAt = createdAt;
+    }
+
+    public static PointTransactionResponse toResponse(PointTransaction pointTransaction){
+
+        String koreanType = Type.toKoreanName(pointTransaction.getType());
+        String convertedCreatedAt = Optional.ofNullable(pointTransaction.getCreatedAt())
+                                            .map(TimeConverter::toStringFormat)
+                                            .orElse(null);
+
+        return PointTransactionResponse.builder()
+                .pointTransactionId(pointTransaction.getId())
+                .type(koreanType)
+                .amount(pointTransaction.getAmount())
+                .createdAt(convertedCreatedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/dto/response/PointTransactionResponseList.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/dto/response/PointTransactionResponseList.java
@@ -1,0 +1,27 @@
+package com.numble.webnovelservice.transaction.dto.response;
+
+import com.numble.webnovelservice.transaction.entity.PointTransaction;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class PointTransactionResponseList {
+
+    private List<PointTransactionResponse> pointTransactionResponses;
+
+    public PointTransactionResponseList(List<PointTransactionResponse> pointTransactionResponses) {
+
+        this.pointTransactionResponses = pointTransactionResponses;
+    }
+
+    public static PointTransactionResponseList toResponse(List<PointTransaction> pointTransactions) {
+
+        List<PointTransactionResponse> responseList = pointTransactions.stream()
+                .map(PointTransactionResponse::toResponse)
+                .collect(Collectors.toList());
+
+        return new PointTransactionResponseList(responseList);
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/entity/PointTransaction.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/entity/PointTransaction.java
@@ -1,0 +1,30 @@
+package com.numble.webnovelservice.transaction.entity;
+
+import com.numble.webnovelservice.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointTransaction extends Transaction{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="point_transaction_id")
+    private Long id;
+
+    @Builder
+    public PointTransaction(Type type, Integer amount, Integer balance, Member member, Long id) {
+        super(type, amount, balance, member);
+        this.id = id;
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/entity/Transaction.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/entity/Transaction.java
@@ -1,0 +1,48 @@
+package com.numble.webnovelservice.transaction.entity;
+
+import com.numble.webnovelservice.member.entity.Member;
+import com.numble.webnovelservice.util.time.Timestamped;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * 이 클래스는 거래 관련 클래스의 상위 클래스입니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class Transaction extends Timestamped {
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private Integer balance;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id")
+    private Member member;
+
+    public Transaction(Type type, Integer amount, Integer balance, Member member) {
+        this.type = type;
+        this.amount = amount;
+        this.balance = balance;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/entity/Type.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/entity/Type.java
@@ -1,0 +1,23 @@
+package com.numble.webnovelservice.transaction.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Type {
+
+    CHARGE("충전"),
+    CONSUME("소모"),
+    ;
+
+    private final String koreanName;
+
+    public static String toKoreanName(Type type) {
+
+        return switch(type) {
+            case CHARGE -> CHARGE.getKoreanName();
+            case CONSUME -> CONSUME.getKoreanName();
+        };
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/repository/PointTransactionRepository.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/repository/PointTransactionRepository.java
@@ -1,0 +1,12 @@
+package com.numble.webnovelservice.transaction.repository;
+
+import com.numble.webnovelservice.member.entity.Member;
+import com.numble.webnovelservice.transaction.entity.PointTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+
+    List<PointTransaction> findByMember(Member member);
+}

--- a/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
@@ -1,0 +1,26 @@
+package com.numble.webnovelservice.transaction.service;
+
+import com.numble.webnovelservice.member.entity.Member;
+import com.numble.webnovelservice.transaction.dto.response.PointTransactionResponseList;
+import com.numble.webnovelservice.transaction.entity.PointTransaction;
+import com.numble.webnovelservice.transaction.repository.PointTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class PointTransactionService {
+
+    private final PointTransactionRepository pointTransactionRepository;
+
+    public PointTransactionResponseList retrieveCurrentMemberPointTransactions(Member member) {
+
+        List<PointTransaction> pointTransactions = pointTransactionRepository.findByMember(member);
+
+        return PointTransactionResponseList.toResponse(pointTransactions);
+    }
+}
+


### PR DESCRIPTION
### 거래 도메인 관련 클래스 추가 및 코드 작성 / 포인트 거래 기록 조회 코드 작성
**Transcation 클래스 추가 및 코드 작성**
- 거래 관련 엔티티의 상위클래스입니다.
- `@MappedSuperclass`, `@EntityListeners(AuditingEntityListener.class)`를 사용하여 상속 기능을 활성화했습니다.

**Type 이넘추가 및 코드 작성**
- 거래 타입을 나타내는 이넘입니다.
- CHARGE("충전")과 CONSUME("소모")가 있습니다. 

**PointTransaction 클래스 추가 및 코드 작성**
- Transaction을 상속받는 포인트 거래 엔티티입니다. 

**PointTransactionRepository 인터페이스 추가 및 코드 작성**
- 객체를 회원 객체로 찾는 `findByMember(Member member)` 메서드 추가

**PointTransactionController 클래스 추가 및 코드 작성**
- 포인트 거래 기록 조회 코드 작성

**PointTransactionService 클래스 추가 및 코드 작성**
- 포인트 거래 기록 조회 코드 작성

**PointTransactionResponse 클래스 추가 및 코드 작성**
- 포인트 거래 기록 조회 시 응답 형식인 response dto

**PointTransactionResponseList 클래스 추가 및 코드 작성**
- PointTransactionResponse를 List형식으로 변환해주는 response dto