### PR TITLE
소장 에피소드 도메인 관련 클래스 추가 및 코드 작성

### DIFF
--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "POINT_TRANSACTION_001", "포인트가 부족합니다."),
 
-    INSUFFICIENT_TICKET(HttpStatus.BAD_REQUEST, "TICKET_TRANSACTION_001", "소장권이 부족합니다."),
+    INSUFFICIENT_TICKET(HttpStatus.BAD_REQUEST, "TICKET_TRANSACTION_002", "소장권이 부족합니다."),
 
     NOT_FOUND_OWNED_EPISODE(HttpStatus.NOT_FOUND, "OWNED_EPISODE_001", "찾을 수 없는 소장 에피소드입니다."),
     PAGE_OUT_OF_BOUND(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_002", "읽을 페이지가 페이지의 범위를 벗어났습니다."),

--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -29,9 +29,15 @@ public enum ErrorCode {
     NOT_VALID_SERIALIZED_STATUS(HttpStatus.BAD_REQUEST, "NOVEL_002", "유효하지 않은 연재 상태입니다."),
     NOT_FOUND_NOVEL(HttpStatus.NOT_FOUND, "NOVEL_003", "찾을 수 없는 소설입니다."),
 
-    NOT_FOUND_EPISODE(HttpStatus.NOT_FOUND, "NOVEL_001", "찾을 수 없는 에피소드입니다."),
+    NOT_FOUND_EPISODE(HttpStatus.NOT_FOUND, "EPISODE_001", "찾을 수 없는 에피소드입니다."),
 
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "POINT_TRANSACTION_001", "포인트가 부족합니다."),
+
+    INSUFFICIENT_TICKET(HttpStatus.BAD_REQUEST, "TICKET_TRANSACTION_001", "소장권이 부족합니다."),
+
+    NOT_FOUND_OWNED_EPISODE(HttpStatus.NOT_FOUND, "OWNED_EPISODE_001", "찾을 수 없는 소장 에피소드입니다."),
+    PAGE_OUT_OF_BOUND(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_002", "읽을 페이지가 페이지의 범위를 벗어났습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
+++ b/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
@@ -1,7 +1,7 @@
 package com.numble.webnovelservice.episode.controller;
 
 import com.numble.webnovelservice.common.response.ResponseMessage;
-import com.numble.webnovelservice.episode.dto.response.EpisodeReadResponse;
+import com.numble.webnovelservice.episode.dto.response.OwnedEpisodeReadResponse;
 import com.numble.webnovelservice.episode.service.OwnedEpisodeService;
 import com.numble.webnovelservice.util.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -30,10 +30,10 @@ public class OwnedEpisodeController {
     }
 
     @PutMapping
-    public ResponseEntity<ResponseMessage<EpisodeReadResponse>> readOwnedEpisode(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                 @PathVariable Long episodeId){
+    public ResponseEntity<ResponseMessage<OwnedEpisodeReadResponse>> readOwnedEpisode(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                      @PathVariable Long episodeId){
 
-        EpisodeReadResponse response = ownedEpisodeService.readOwnedEpisode(userDetails.getMember(), episodeId);
+        OwnedEpisodeReadResponse response = ownedEpisodeService.readOwnedEpisode(userDetails.getMember(), episodeId);
         return new ResponseEntity<>(new ResponseMessage<>("에피소드 열람 성공",response), HttpStatus.OK);
     }
 

--- a/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
+++ b/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
@@ -1,0 +1,55 @@
+package com.numble.webnovelservice.episode.controller;
+
+import com.numble.webnovelservice.common.response.ResponseMessage;
+import com.numble.webnovelservice.episode.dto.response.EpisodeReadResponse;
+import com.numble.webnovelservice.episode.service.OwnedEpisodeService;
+import com.numble.webnovelservice.util.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/episodes/{episodeId}")
+public class OwnedEpisodeController {
+
+    private final OwnedEpisodeService ownedEpisodeService;
+
+    @PostMapping
+    public ResponseEntity<ResponseMessage<Void>> purchaseEpisode(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                 @PathVariable Long episodeId){
+
+        ownedEpisodeService.purchaseEpisode(userDetails.getMember(), episodeId);
+        return new ResponseEntity<>(new ResponseMessage<>("에피소드 구매 성공",null), HttpStatus.CREATED);
+    }
+
+    @PutMapping
+    public ResponseEntity<ResponseMessage<EpisodeReadResponse>> readOwnedEpisode(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                 @PathVariable Long episodeId){
+
+        EpisodeReadResponse response = ownedEpisodeService.readOwnedEpisode(userDetails.getMember(), episodeId);
+        return new ResponseEntity<>(new ResponseMessage<>("에피소드 열람 성공",response), HttpStatus.OK);
+    }
+
+    @PutMapping
+    public ResponseEntity<ResponseMessage<Void>> readOwnedEpisodeNextPage(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                            @PathVariable Long episodeId){
+
+        ownedEpisodeService.readOwnedEpisodeNextPage(userDetails.getMember(), episodeId);
+        return new ResponseEntity<>(new ResponseMessage<>("에피소드 다음 페이지 읽기 성공", null), HttpStatus.OK);
+    }
+
+    @PutMapping
+    public ResponseEntity<ResponseMessage<Void>> readOwnedEpisodePreviousPage(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @PathVariable Long episodeId){
+
+        ownedEpisodeService.readOwnedEpisodePreviousPage(userDetails.getMember(), episodeId);
+        return new ResponseEntity<>(new ResponseMessage<>("에피소드 이전 페이지 읽기 성공", null), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/episode/dto/response/EpisodeReadResponse.java
+++ b/src/main/java/com/numble/webnovelservice/episode/dto/response/EpisodeReadResponse.java
@@ -1,0 +1,28 @@
+package com.numble.webnovelservice.episode.dto.response;
+
+import com.numble.webnovelservice.episode.entity.OwnedEpisode;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EpisodeReadResponse {
+
+    private String content;
+
+    private Integer currentReadingPage;
+
+    @Builder
+    public EpisodeReadResponse(String content, Integer currentReadingPage) {
+
+        this.content = content;
+        this.currentReadingPage = currentReadingPage;
+    }
+
+    public static EpisodeReadResponse toResponse(OwnedEpisode ownedEpisode) {
+
+        return EpisodeReadResponse.builder()
+                .content(ownedEpisode.getEpisode().getContent())
+                .currentReadingPage(ownedEpisode.getCurrentReadingPage())
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/episode/dto/response/OwnedEpisodeReadResponse.java
+++ b/src/main/java/com/numble/webnovelservice/episode/dto/response/OwnedEpisodeReadResponse.java
@@ -5,22 +5,22 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class EpisodeReadResponse {
+public class OwnedEpisodeReadResponse {
 
     private String content;
 
     private Integer currentReadingPage;
 
     @Builder
-    public EpisodeReadResponse(String content, Integer currentReadingPage) {
+    public OwnedEpisodeReadResponse(String content, Integer currentReadingPage) {
 
         this.content = content;
         this.currentReadingPage = currentReadingPage;
     }
 
-    public static EpisodeReadResponse toResponse(OwnedEpisode ownedEpisode) {
+    public static OwnedEpisodeReadResponse toResponse(OwnedEpisode ownedEpisode) {
 
-        return EpisodeReadResponse.builder()
+        return OwnedEpisodeReadResponse.builder()
                 .content(ownedEpisode.getEpisode().getContent())
                 .currentReadingPage(ownedEpisode.getCurrentReadingPage())
                 .build();

--- a/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
+++ b/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
@@ -77,4 +77,9 @@ public class Episode extends Timestamped {
         this.neededTicketCount = request.getNeededTicketCount();
         this.fileSize = request.getFileSize();
     }
+
+    public void incrementViewCount(){
+
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/numble/webnovelservice/episode/entity/OwnedEpisode.java
+++ b/src/main/java/com/numble/webnovelservice/episode/entity/OwnedEpisode.java
@@ -1,0 +1,80 @@
+package com.numble.webnovelservice.episode.entity;
+
+import com.numble.webnovelservice.member.entity.Member;
+import com.numble.webnovelservice.util.time.Timestamped;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.util.Optional;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnedEpisode extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="owned_episode_id")
+    private Long id;
+
+    @Column(nullable = true)
+    private Integer currentReadingPage;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="episode_id")
+    private Episode episode;
+
+    @Builder
+    public OwnedEpisode(Long id, Integer currentReadingPage, Boolean isRead, Member member, Episode episode) {
+
+        this.id = id;
+        this.currentReadingPage = currentReadingPage;
+        this.isRead = isRead;
+        this.member = member;
+        this.episode = episode;
+    }
+
+    public static OwnedEpisode createOwnedEpisode(Member member, Episode episode) {
+
+        return OwnedEpisode.builder()
+                .isRead(false)
+                .currentReadingPage(null)
+                .episode(episode)
+                .member(member)
+                .build();
+    }
+
+    public void markAsRead(){
+
+        this.isRead = true;
+        this.currentReadingPage = Optional.ofNullable(currentReadingPage)
+                                    .orElse(1);
+    }
+
+    public void readNextPage(){
+
+        currentReadingPage++;
+    }
+
+    public void readPreviousPage(){
+
+        currentReadingPage--;
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/episode/repository/OwnedEpisodeRepository.java
+++ b/src/main/java/com/numble/webnovelservice/episode/repository/OwnedEpisodeRepository.java
@@ -1,0 +1,11 @@
+package com.numble.webnovelservice.episode.repository;
+
+import com.numble.webnovelservice.episode.entity.OwnedEpisode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OwnedEpisodeRepository extends JpaRepository<OwnedEpisode, Long> {
+
+    Optional<OwnedEpisode> findByMemberIdAndEpisodeId(Long memberId, Long episodeId);
+}

--- a/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
@@ -1,7 +1,7 @@
 package com.numble.webnovelservice.episode.service;
 
 import com.numble.webnovelservice.common.exception.WebNovelServiceException;
-import com.numble.webnovelservice.episode.dto.response.EpisodeReadResponse;
+import com.numble.webnovelservice.episode.dto.response.OwnedEpisodeReadResponse;
 import com.numble.webnovelservice.episode.entity.Episode;
 import com.numble.webnovelservice.episode.entity.OwnedEpisode;
 import com.numble.webnovelservice.episode.repository.EpisodeRepository;
@@ -65,7 +65,7 @@ public class OwnedEpisodeService {
     }
 
     @Transactional
-    public EpisodeReadResponse readOwnedEpisode(Member currentMember, Long episodeId) {
+    public OwnedEpisodeReadResponse readOwnedEpisode(Member currentMember, Long episodeId) {
 
         OwnedEpisode ownedEpisode = ownedEpisodeRepository.findByMemberIdAndEpisodeId(currentMember.getId(), episodeId).orElseThrow(
                 () -> new WebNovelServiceException(NOT_FOUND_OWNED_EPISODE)
@@ -80,7 +80,7 @@ public class OwnedEpisodeService {
 
         novel.incrementTotalViewCount();
 
-        return EpisodeReadResponse.toResponse(ownedEpisode);
+        return OwnedEpisodeReadResponse.toResponse(ownedEpisode);
     }
 
     @Transactional

--- a/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
@@ -1,0 +1,128 @@
+package com.numble.webnovelservice.episode.service;
+
+import com.numble.webnovelservice.common.exception.WebNovelServiceException;
+import com.numble.webnovelservice.episode.dto.response.EpisodeReadResponse;
+import com.numble.webnovelservice.episode.entity.Episode;
+import com.numble.webnovelservice.episode.entity.OwnedEpisode;
+import com.numble.webnovelservice.episode.repository.EpisodeRepository;
+import com.numble.webnovelservice.episode.repository.OwnedEpisodeRepository;
+import com.numble.webnovelservice.member.entity.Member;
+import com.numble.webnovelservice.member.repository.MemberRepository;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.transaction.entity.TicketTransaction;
+import com.numble.webnovelservice.transaction.repository.TicketTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.numble.webnovelservice.common.exception.ErrorCode.INSUFFICIENT_TICKET;
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_EPISODE;
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_OWNED_EPISODE;
+import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_OUT_OF_BOUND;
+
+@Service
+@RequiredArgsConstructor
+public class OwnedEpisodeService {
+
+    private final OwnedEpisodeRepository ownedEpisodeRepository;
+    private final EpisodeRepository episodeRepository;
+    private final MemberRepository memberRepository;
+    private final TicketTransactionRepository ticketTransactionRepository;
+
+    @Transactional
+    public void purchaseEpisode(Member currentMember, Long episodeId) {
+
+        Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_MEMBER)
+        );
+
+        Episode episode = episodeRepository.findById(episodeId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_EPISODE)
+        );
+
+        int availableTickets = member.getTicketCount();
+        int requiredTickets = episode.getNeededTicketCount();
+
+        throwIfInsufficientTicket(availableTickets, requiredTickets);
+
+        member.consumeTicket(requiredTickets);
+
+        OwnedEpisode ownedEpisode = OwnedEpisode.createOwnedEpisode(member, episode);
+
+        ownedEpisodeRepository.save(ownedEpisode);
+
+        TicketTransaction ticketTransaction = TicketTransaction.createConsumeTicketTransaction(member, requiredTickets);
+
+        ticketTransactionRepository.save(ticketTransaction);
+    }
+
+    private static void throwIfInsufficientTicket(int availableTickets, int requiredTickets) {
+
+        if(availableTickets < requiredTickets){
+             throw new WebNovelServiceException(INSUFFICIENT_TICKET);
+        }
+    }
+
+    @Transactional
+    public EpisodeReadResponse readOwnedEpisode(Member currentMember, Long episodeId) {
+
+        OwnedEpisode ownedEpisode = ownedEpisodeRepository.findByMemberIdAndEpisodeId(currentMember.getId(), episodeId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_OWNED_EPISODE)
+        );
+
+        Episode episode = ownedEpisode.getEpisode();
+        Novel novel = episode.getNovel();
+
+        ownedEpisode.markAsRead();
+
+        episode.incrementViewCount();
+
+        novel.incrementTotalViewCount();
+
+        return EpisodeReadResponse.toResponse(ownedEpisode);
+    }
+
+    @Transactional
+    public void readOwnedEpisodeNextPage(Member currentMember, Long episodeId) {
+
+        OwnedEpisode ownedEpisode = ownedEpisodeRepository.findByMemberIdAndEpisodeId(currentMember.getId(), episodeId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_OWNED_EPISODE)
+        );
+
+        Episode episode = ownedEpisode.getEpisode();
+
+        int totalPage = episode.getTotalPageCount();
+        int currentReadingPage = ownedEpisode.getCurrentReadingPage();
+
+        throwIfInvalidPageNumber(currentReadingPage, totalPage);
+
+        ownedEpisode.readNextPage();
+    }
+
+    private static void throwIfInvalidPageNumber(int currentReadingPage, int totalPage) {
+        if(currentReadingPage >= totalPage){
+            throw new WebNovelServiceException(PAGE_OUT_OF_BOUND);
+        }
+    }
+
+    @Transactional
+    public void readOwnedEpisodePreviousPage(Member currentMember, Long episodeId) {
+
+        OwnedEpisode ownedEpisode = ownedEpisodeRepository.findByMemberIdAndEpisodeId(currentMember.getId(), episodeId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_OWNED_EPISODE)
+        );
+
+        int currentReadingPage = ownedEpisode.getCurrentReadingPage();
+
+        throwIfInvalidPageNumber(currentReadingPage);
+
+        ownedEpisode.readPreviousPage();
+    }
+
+    private static void throwIfInvalidPageNumber(int currentReadingPage) {
+        if(currentReadingPage <= 1){
+            throw new WebNovelServiceException(PAGE_OUT_OF_BOUND);
+        }
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/member/entity/Member.java
+++ b/src/main/java/com/numble/webnovelservice/member/entity/Member.java
@@ -42,6 +42,7 @@ public class Member extends Timestamped{
 
     @Builder
     public Member(Long id, String username, String password, String nickname, String profileImage, Integer pointAmount, Integer ticketCount) {
+
         this.id = id;
         this.username = username;
         this.password = password;
@@ -52,10 +53,12 @@ public class Member extends Timestamped{
     }
 
     public void updateNickname(String nickname){
+
         this.nickname = nickname;
     }
 
     public void updateProfileImage(String profileImage){
+
         this.profileImage = profileImage;
     }
 
@@ -68,5 +71,10 @@ public class Member extends Timestamped{
 
         this.pointAmount -= 100 * amount;
         this.ticketCount += amount;
+    }
+
+    public void consumeTicket(int requiredTickets) {
+
+        this.ticketCount -= requiredTickets;
     }
 }

--- a/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
@@ -83,4 +83,9 @@ public class Novel extends Timestamped {
 
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void incrementTotalViewCount(){
+
+        this.totalViewCount++;
+    }
 }

--- a/src/main/java/com/numble/webnovelservice/transaction/entity/TicketTransaction.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/entity/TicketTransaction.java
@@ -12,6 +12,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+import static com.numble.webnovelservice.transaction.entity.Type.CONSUME;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,5 +28,19 @@ public class TicketTransaction extends Transaction{
     public TicketTransaction(Type type, Integer amount, Integer balance, Member member, Long id) {
         super(type, amount, balance, member);
         this.id = id;
+    }
+
+
+    public static TicketTransaction createConsumeTicketTransaction(Member member, int amount) {
+
+        Type type = CONSUME;
+        Integer balance = member.getTicketCount() - amount;
+
+        return TicketTransaction.builder()
+                                .type(type)
+                                .amount(amount)
+                                .balance(balance)
+                                .member(member)
+                                .build();
     }
 }

--- a/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
@@ -41,11 +41,13 @@ public class TicketTransactionService {
                 () -> new WebNovelServiceException(NOT_FOUND_MEMBER)
         );
 
-        Integer amount = request.getAmount();
+        Integer ticketAmount = request.getAmount();
+        Integer requiredPoint = ticketAmount * 100;
+        Integer availablePoint = member.getPointAmount();
 
-        throwIfNotEnoughPoint(amount, member);
+        throwIfInsufficientPoint(availablePoint, requiredPoint);
 
-        member.chargeTicket(amount);
+        member.chargeTicket(ticketAmount);
 
         TicketTransaction ticketTransaction = request.toTicketTransaction(member);
 
@@ -56,11 +58,9 @@ public class TicketTransactionService {
         pointTransactionRepository.save(pointTransaction);
     }
 
-    private void throwIfNotEnoughPoint(Integer ticketAmount, Member member) {
+    private void throwIfInsufficientPoint(Integer availablePoint, Integer requiredPoint) {
 
-        Integer requiredPoint = ticketAmount * 100;
-
-        if (member.getPointAmount() < requiredPoint) {
+        if (availablePoint < requiredPoint) {
             throw new WebNovelServiceException(INSUFFICIENT_POINT);
         }
     }


### PR DESCRIPTION
### 소장 에피소드 도메인 관련 클래스 추가 및 코드 작성
**추가한 기능 목록**
- 에피소드 구매
- 소장 에피소드 열람
- 소장 에피소드 다음 페이지로 넘김
- 소장 에피소드 이전 페이지로 넘김

**OwnedEpisode 클래스 추가 및 코드 작성**
- `createOwnedEpisode()`: 객체를 생성해주는 팩토리 메서드 작성
- update 메서드 작성
  - `markAsRead()`: 읽음  처리 시 읽음 상태를 변화 시키고, 현재 읽는 페이지가 null 이라면 1로 변경합니다.
  -  `readNextPage`: 현재 읽고 있는 페이지를 증가시킵니다.
  - `readPreviousPage`: 현재 읽고 있는 페이지를 감소시킵니다.
  
**OwnedEpisodeRepository 인터페이스 추가 및 코드 작성**
- `findByMemberIdAndEpisodeId()`: 멤버 Id 와 에피소드 Id로 객체를 찾는 메서드입니다.

**OwnedEpisodeController 클래스 추가 및 코드 작성**
- 작성한 기능 목록
  -  `purchaseEpisode()`: 에피소드 구매
  - `readOwnedEpisode()`: 소장 에피소드 열람
  - `readOwnedEpisodeNextPage()` : 소장 에피소드 다음 페이지로 넘김
  - `readOwnedEpisodePreviousPage()`: 소장 에피소드 이전 페이지로 넘김
 
**OwnedEpisodeService 클래스 추가 및 코드 작성**
 - 작성한 기능 목록
  -  `purchaseEpisode()`: 에피소드 구매
  - `readOwnedEpisode()`: 소장 에피소드 열람
  - `readOwnedEpisodeNextPage()` : 소장 에피소드 다음 페이지로 넘김
  - `readOwnedEpisodePreviousPage()`: 소장 에피소드 이전 페이지로 넘김
  
**`purchaseEpisode()` 코드에 대한 설명:**
- 로그인한 회원의 id와 PathVariable로 받은 에피소드의 id로 각각 회원과 에피소드 객체를 찾습니다.
- 회원이 보유한 티켓 수와 구매하려는 에피소드의 필요한 티켓 수를 비교합니다. 
  - 만약 필요한 티켓 수가 회원이 보유한 티켓 수보다 많다면 예외를 반환합니다.
- 회원의 티켓 수를 차감합니다.
- 소장 에피소드(OwnedEpisode) 객체를 생성하고 저장합니다.
  - 소장 에피소드는 회원이 소유한 에피소드 정보를 담고 있습니다.
- 티켓 거래(TicketTransaction) 객체를 생성하고 저장합니다.
  - 티켓 거래는 회원이 티켓을 소모한 내역을 기록합니다.
  
**`readOwnedEpisode()` 코드에 대한 설명:**
- 로그인한 회원의 id와 PathVariable로 받은 에피소드의 id로 각각 소장 에피소드 객체를 찾습니다.
- 소장 에피소드에 저장된 에피소드 객체를 가져옵니다. 
- 에피소드에 저장된 소설 객체를 가져옵니다.
- 소장 에피소드를 읽음 처리 합니다.
- 에피소드의 조회 수를 증가시킵니다.
- 소설의 총 조회 수를 증가시킵니다.
- 소설이 저장된 주소(content) 와 현재 읽고 있는 페이지를 반환합니다.

**OwnedEpisodeReadResponse 클래스 추가 및 코드 작성**
- 소장 에피소드 열람 시 필요한 response dto 입니다.