### PR TITLE
홈 노출 도메인 관련 클래스 추가 및 코드 작성

### DIFF
--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -36,10 +36,14 @@ public enum ErrorCode {
     INSUFFICIENT_TICKET(HttpStatus.BAD_REQUEST, "TICKET_TRANSACTION_002", "소장권이 부족합니다."),
 
     NOT_FOUND_OWNED_EPISODE(HttpStatus.NOT_FOUND, "OWNED_EPISODE_001", "찾을 수 없는 소장 에피소드입니다."),
-    PAGE_OUT_OF_BOUND(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_002", "읽을 페이지가 페이지의 범위를 벗어났습니다."),
+    PAGE_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_002", "읽을 페이지가 페이지의 범위를 벗어났습니다."),
 
     DUPLICATE_FAVORITE_NOVEL(HttpStatus.BAD_REQUEST, "FAVORITE_NOVEL_001", "이미 등록된 선호 작품입니다."),
     NOT_FOUND_FAVORITE_NOVEL(HttpStatus.NOT_FOUND, "FAVORITE_NOVEL_002", "찾을 수 없는 선호 작품입니다."),
+
+    DUPLICATE_HOME_EXPOSURE(HttpStatus.BAD_REQUEST, "HOME_EXPOSURE_001", "이미 등록된 홈 노출입니다."),
+    NOT_FOUND_HOME_EXPOSURE(HttpStatus.NOT_FOUND, "HOME_EXPOSURE_002", "찾을 수 없는 홈 노출입니다."),
+    HOME_EXPOSURE_COUNT_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "HOME_EXPOSURE_003", "홈 노출 저장 범위를 벗어났습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/episode/service/OwnedEpisodeService.java
@@ -22,7 +22,7 @@ import static com.numble.webnovelservice.common.exception.ErrorCode.INSUFFICIENT
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_EPISODE;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_OWNED_EPISODE;
-import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_OUT_OF_BOUND;
+import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_OUT_OF_BOUNDS;
 
 @Service
 @RequiredArgsConstructor
@@ -106,7 +106,7 @@ public class OwnedEpisodeService {
     private void throwIfInvalidPageNumber(int currentReadingPage, int totalPage) {
         
         if(currentReadingPage >= totalPage){
-            throw new WebNovelServiceException(PAGE_OUT_OF_BOUND);
+            throw new WebNovelServiceException(PAGE_OUT_OF_BOUNDS);
         }
     }
 
@@ -127,7 +127,7 @@ public class OwnedEpisodeService {
     private void throwIfInvalidPageNumber(int currentReadingPage) {
 
         if(currentReadingPage <= 1){
-            throw new WebNovelServiceException(PAGE_OUT_OF_BOUND);
+            throw new WebNovelServiceException(PAGE_OUT_OF_BOUNDS);
         }
     }
 

--- a/src/main/java/com/numble/webnovelservice/favoritenovel/controller/FavoriteNovelController.java
+++ b/src/main/java/com/numble/webnovelservice/favoritenovel/controller/FavoriteNovelController.java
@@ -22,7 +22,7 @@ public class FavoriteNovelController {
 
     private final FavoriteNovelService favoriteNovelService;
 
-    @PostMapping("/novels/{novelId}")
+    @PostMapping("/novels/{novelId}/favorite-novels")
     public ResponseEntity<ResponseMessage<Void>> registerFavoriteNovel(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                        @PathVariable Long novelId){
 
@@ -30,7 +30,7 @@ public class FavoriteNovelController {
         return new ResponseEntity<>(new ResponseMessage<>("선호 작품 등록 성공",null), HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/novels/{novelId}")
+    @DeleteMapping("/novels/{novelId}/favorite-novels")
     public ResponseEntity<ResponseMessage<Void>> removeFavoriteNovel(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                        @PathVariable Long novelId){
 

--- a/src/main/java/com/numble/webnovelservice/homeexposure/controller/HomeExposureController.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/controller/HomeExposureController.java
@@ -1,0 +1,43 @@
+package com.numble.webnovelservice.homeexposure.controller;
+
+import com.numble.webnovelservice.common.response.ResponseMessage;
+import com.numble.webnovelservice.homeexposure.dto.response.HomeExposureInfoResponseList;
+import com.numble.webnovelservice.homeexposure.service.HomeExposureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class HomeExposureController {
+
+    private final HomeExposureService homeExposureService;
+
+    @PostMapping("/novels/{novelId}/home-exposures")
+    public ResponseEntity<ResponseMessage<Void>> registerHomeExposure(@PathVariable Long novelId){
+
+        homeExposureService.registerHomeExposure(novelId);
+        return new ResponseEntity<>(new ResponseMessage<>("홈 노출 등록 성공",null), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/novels/{novelId}/home-exposures")
+    public ResponseEntity<ResponseMessage<Void>> removeHomeExposure(@PathVariable Long novelId){
+
+        homeExposureService.removeHomeExposure(novelId);
+        return new ResponseEntity<>(new ResponseMessage<>("홈 노출 삭제 성공",null), HttpStatus.OK);
+    }
+
+    @GetMapping("/home-exposures")
+    public ResponseEntity<ResponseMessage<HomeExposureInfoResponseList>> retrieveAllHomeExposures(){
+
+        HomeExposureInfoResponseList response = homeExposureService.retrieveAllHomeExposures();
+        return new ResponseEntity<>(new ResponseMessage<>("홈 노출 조회 성공", response), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/homeexposure/dto/response/HomeExposureInfoResponse.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/dto/response/HomeExposureInfoResponse.java
@@ -1,0 +1,73 @@
+package com.numble.webnovelservice.homeexposure.dto.response;
+
+import com.numble.webnovelservice.homeexposure.entity.HomeExposure;
+import com.numble.webnovelservice.novel.entity.Genre;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.entity.SerializedStatus;
+import com.numble.webnovelservice.util.time.TimeConverter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public class HomeExposureInfoResponse {
+
+    private Long homeExposureId;
+
+    private Long novelId;
+
+    private String title;
+
+    private String author;
+
+    private String genre;
+
+    private String coverImage;
+
+    private String serializedStatus;
+
+    private Integer likeCount;
+
+    private Integer totalViewCount;
+
+    private String updatedAt;
+
+    @Builder
+    public HomeExposureInfoResponse(Long homeExposureId, Long novelId, String title, String author, String genre, String coverImage, String serializedStatus, Integer likeCount, Integer totalViewCount, String updatedAt) {
+
+        this.homeExposureId = homeExposureId;
+        this.novelId = novelId;
+        this.title = title;
+        this.author = author;
+        this.genre = genre;
+        this.coverImage = coverImage;
+        this.serializedStatus = serializedStatus;
+        this.likeCount = likeCount;
+        this.totalViewCount = totalViewCount;
+        this.updatedAt = updatedAt;
+    }
+
+    public static HomeExposureInfoResponse toResponse(HomeExposure homeExposure){
+
+        Novel novel = homeExposure.getNovel();
+        String koreanGenre = Genre.toKoreanName(novel.getGenre());
+        String koreanSerializedStatus = SerializedStatus.toKoreanName(novel.getSerializedStatus());
+        String convertedUpdatedAt = Optional.ofNullable(novel.getUpdatedAt())
+                .map(TimeConverter::toStringFormat)
+                .orElse(null);
+
+        return HomeExposureInfoResponse.builder()
+                .homeExposureId(homeExposure.getId())
+                .novelId(novel.getId())
+                .title(novel.getTitle())
+                .author(novel.getAuthor())
+                .genre(koreanGenre)
+                .coverImage(novel.getCoverImage())
+                .serializedStatus(koreanSerializedStatus)
+                .likeCount(novel.getLikeCount())
+                .totalViewCount(novel.getTotalViewCount())
+                .updatedAt(convertedUpdatedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/homeexposure/dto/response/HomeExposureInfoResponseList.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/dto/response/HomeExposureInfoResponseList.java
@@ -1,0 +1,28 @@
+package com.numble.webnovelservice.homeexposure.dto.response;
+
+import com.numble.webnovelservice.homeexposure.entity.HomeExposure;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class HomeExposureInfoResponseList {
+
+    private List<HomeExposureInfoResponse> homeExposures;
+
+    public HomeExposureInfoResponseList(List<HomeExposureInfoResponse> homeExposures) {
+
+        this.homeExposures = homeExposures;
+    }
+
+    public static HomeExposureInfoResponseList toResponse(List<HomeExposure> homeExposures) {
+
+        List<HomeExposureInfoResponse> responseList = homeExposures.stream()
+                .map(HomeExposureInfoResponse::toResponse)
+                .collect(Collectors.toList());
+
+        return new HomeExposureInfoResponseList(responseList);
+
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/homeexposure/entity/HomeExposure.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/entity/HomeExposure.java
@@ -1,0 +1,45 @@
+package com.numble.webnovelservice.homeexposure.entity;
+
+import com.numble.webnovelservice.novel.entity.Novel;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HomeExposure {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="favorite_novel_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="novel_id")
+    private Novel novel;
+
+    @Builder
+    public HomeExposure(Long id, Novel novel) {
+
+        this.id = id;
+        this.novel = novel;
+    }
+
+    public static HomeExposure createHomeExposure(Novel novel){
+
+        return HomeExposure.builder()
+                .novel(novel)
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/homeexposure/repository/HomeExposureRepository.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/repository/HomeExposureRepository.java
@@ -1,0 +1,13 @@
+package com.numble.webnovelservice.homeexposure.repository;
+
+import com.numble.webnovelservice.homeexposure.entity.HomeExposure;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HomeExposureRepository extends JpaRepository<HomeExposure, Long> {
+
+    boolean existsByNovelId(Long novelId);
+
+    Optional<HomeExposure> findByNovelId(Long novelId);
+}

--- a/src/main/java/com/numble/webnovelservice/homeexposure/service/HomeExposureService.java
+++ b/src/main/java/com/numble/webnovelservice/homeexposure/service/HomeExposureService.java
@@ -1,0 +1,75 @@
+package com.numble.webnovelservice.homeexposure.service;
+
+import com.numble.webnovelservice.common.exception.WebNovelServiceException;
+import com.numble.webnovelservice.homeexposure.dto.response.HomeExposureInfoResponseList;
+import com.numble.webnovelservice.homeexposure.entity.HomeExposure;
+import com.numble.webnovelservice.homeexposure.repository.HomeExposureRepository;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.repository.NovelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.numble.webnovelservice.common.exception.ErrorCode.DUPLICATE_HOME_EXPOSURE;
+import static com.numble.webnovelservice.common.exception.ErrorCode.HOME_EXPOSURE_COUNT_OUT_OF_BOUNDS;
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_HOME_EXPOSURE;
+import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_NOVEL;
+
+@Service
+@RequiredArgsConstructor
+public class HomeExposureService {
+
+    private final HomeExposureRepository homeExposureRepository;
+    private final NovelRepository novelRepository;
+
+    @Transactional
+    public void registerHomeExposure(Long novelId) {
+
+        throwIfDuplicateHomeExposure(novelId);
+        throwIfInvalidHomeExposureCount();
+
+        Novel novel = novelRepository.findById(novelId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_NOVEL)
+        );
+
+        HomeExposure homeExposure = HomeExposure.createHomeExposure(novel);
+
+        homeExposureRepository.save(homeExposure);
+    }
+
+    private void throwIfDuplicateHomeExposure(Long novelId) {
+
+        if(homeExposureRepository.existsByNovelId(novelId)){
+            throw new WebNovelServiceException(DUPLICATE_HOME_EXPOSURE);
+        }
+    }
+
+    private void throwIfInvalidHomeExposureCount() {
+
+        final int MAX_HOME_EXPOSURE_COUNT = 10;
+
+        if (novelRepository.count() >= MAX_HOME_EXPOSURE_COUNT) {
+            throw new WebNovelServiceException(HOME_EXPOSURE_COUNT_OUT_OF_BOUNDS);
+        }
+    }
+
+    @Transactional
+    public void removeHomeExposure(Long novelId) {
+
+        HomeExposure homeExposure = homeExposureRepository.findByNovelId(novelId).orElseThrow(
+                () -> new WebNovelServiceException(NOT_FOUND_HOME_EXPOSURE)
+        );
+
+        homeExposureRepository.delete(homeExposure);
+    }
+
+    @Transactional(readOnly = true)
+    public HomeExposureInfoResponseList retrieveAllHomeExposures() {
+
+        List<HomeExposure> homeExposures = homeExposureRepository.findAll();
+
+        return HomeExposureInfoResponseList.toResponse(homeExposures);
+    }
+}


### PR DESCRIPTION
### 홈 노출 도메인 관련 클래스 추가 및 코드 작성

**추가한 기능 목록**
- 홈 노출 등록
- 홈 노출 삭제
- 홈 노출 전체 조회

**HomeExposure 클래스 추가 및 코드 작성**
- 객체를 만들어주는 팩토리 메서드인 `createHomeExposure`를 작성하였습니다.

**HomeExposureRepository 클래스 추가 및 코드 작성**
- `existsByNovelId`: 소설id로 홈 노출이 존재하는지 boolean 값을 반환합니다.
- `findByNovelId`: 소설id로 홈 노출을 찾습니다.

**HomeExposureController 클래스 추가 및 코드 작성**
- `registerHomeExposure()`: 홈 노출 등록 메서드
- `removeHomeExposure()`: 홈 노출 삭제 메서드
- `retrieveAllHomeExposures()`: 홈 노출 전체 조회 메서드

**HomeExposureService 클래스 추가 및 코드 작성**
- `registerHomeExposure()`: 홈 노출 등록 메서드
  - `throwIfDuplicateHomeExposure()`: 홈 노출에 등록할 소설이 존재한다면 예외를 반환합니다.
  - `throwIfInvalidHomeExposureCount()`: 홈 노출의 수가 10개 이상이라면 예외를 반환합니다. 
- `removeHomeExposure()`: 홈 노출 삭제 메서드
- `retrieveAllHomeExposures()`: 홈 노출 전체 조회 메서드

**HomeExposureInfoResponse 클래스 추가 및 코드 작성**
- 홈 노출 조회 시 응답형식인 response dto 입니다.

**HomeExposureInfoResponseList 클래스 추가 및 코드 작성**
- HomeExposureInfoResponse 를 List로 받는 response dto 입니다.