### PR TITLE
소설 상세 조회 기능 작성 / 소설 소장 시 양방향 연관관계 및 예외 처리 추가

### DIFF
--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -37,9 +37,10 @@ public enum ErrorCode {
 
     NOT_FOUND_OWNED_EPISODE(HttpStatus.NOT_FOUND, "OWNED_EPISODE_001", "찾을 수 없는 소장 에피소드입니다."),
     PAGE_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_002", "읽을 페이지가 페이지의 범위를 벗어났습니다."),
+    DUPLICATE_OWNED_EPISODE(HttpStatus.BAD_REQUEST, "OWNED_EPISODE_003", "이미 등록된 소장 에피소드입니다."),
 
-    DUPLICATE_FAVORITE_NOVEL(HttpStatus.BAD_REQUEST, "FAVORITE_NOVEL_001", "이미 등록된 선호 작품입니다."),
-    NOT_FOUND_FAVORITE_NOVEL(HttpStatus.NOT_FOUND, "FAVORITE_NOVEL_002", "찾을 수 없는 선호 작품입니다."),
+    DUPLICATE_FAVORITE_NOVEL(HttpStatus.BAD_REQUEST, "FAVORITE_NOVEL_001", "이미 등록된 선호 소설입니다."),
+    NOT_FOUND_FAVORITE_NOVEL(HttpStatus.NOT_FOUND, "FAVORITE_NOVEL_002", "찾을 수 없는 선호 소설입니다."),
 
     DUPLICATE_HOME_EXPOSURE(HttpStatus.BAD_REQUEST, "HOME_EXPOSURE_001", "이미 등록된 홈 노출입니다."),
     NOT_FOUND_HOME_EXPOSURE(HttpStatus.NOT_FOUND, "HOME_EXPOSURE_002", "찾을 수 없는 홈 노출입니다."),

--- a/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
+++ b/src/main/java/com/numble/webnovelservice/episode/controller/OwnedEpisodeController.java
@@ -39,7 +39,7 @@ public class OwnedEpisodeController {
         return new ResponseEntity<>(new ResponseMessage<>("에피소드 열람 성공",response), HttpStatus.OK);
     }
 
-    @PutMapping("/{episodeId}")
+    @PutMapping("/{episodeId}/next-page")
     public ResponseEntity<ResponseMessage<Void>> readOwnedEpisodeNextPage(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                             @PathVariable Long episodeId){
 
@@ -47,7 +47,7 @@ public class OwnedEpisodeController {
         return new ResponseEntity<>(new ResponseMessage<>("에피소드 다음 페이지 읽기 성공", null), HttpStatus.OK);
     }
 
-    @PutMapping("/{episodeId}")
+    @PutMapping("/{episodeId}/previous-page")
     public ResponseEntity<ResponseMessage<Void>> readOwnedEpisodePreviousPage(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                           @PathVariable Long episodeId){
 

--- a/src/main/java/com/numble/webnovelservice/episode/dto/response/EpisodeDetailsResponse.java
+++ b/src/main/java/com/numble/webnovelservice/episode/dto/response/EpisodeDetailsResponse.java
@@ -1,0 +1,69 @@
+package com.numble.webnovelservice.episode.dto.response;
+
+import com.numble.webnovelservice.episode.entity.Episode;
+import com.numble.webnovelservice.episode.entity.OwnedEpisode;
+import com.numble.webnovelservice.util.time.TimeConverter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public class EpisodeDetailsResponse {
+
+    private Long episodeId;
+
+    private String title;
+
+    private Integer totalPageCount;
+
+    private Float fileSize;
+
+    private Boolean isFree;
+
+    private Integer neededTicketCount;
+
+    private Boolean isOwnedEpisode;
+
+    private Boolean isRead;
+
+    private String createdAt;
+
+    @Builder
+    public EpisodeDetailsResponse(Long episodeId, String title, Integer totalPageCount, Float fileSize, Boolean isFree, Integer neededTicketCount, Boolean isOwnedEpisode, Boolean isRead, String createdAt) {
+
+        this.episodeId = episodeId;
+        this.title = title;
+        this.totalPageCount = totalPageCount;
+        this.fileSize = fileSize;
+        this.isFree = isFree;
+        this.neededTicketCount = neededTicketCount;
+        this.isOwnedEpisode = isOwnedEpisode;
+        this.isRead = isRead;
+        this.createdAt = createdAt;
+    }
+
+    public static EpisodeDetailsResponse toResponse(Episode episode, OwnedEpisode ownedEpisode) {
+
+        String convertedCreatedAt = Optional.ofNullable(episode.getCreatedAt())
+                .map(TimeConverter::toStringFormat)
+                .orElse(null);
+
+        boolean isOwnedEpisode = ownedEpisode != null;
+        boolean isRead = Optional.ofNullable(ownedEpisode)
+                .map(OwnedEpisode::getIsRead)
+                .orElse(false);
+
+        return EpisodeDetailsResponse.builder()
+                .episodeId(episode.getId())
+                .title(episode.getTitle())
+                .totalPageCount(episode.getTotalPageCount())
+                .fileSize(episode.getFileSize())
+                .isFree(episode.getIsFree())
+                .neededTicketCount(episode.getNeededTicketCount())
+                .isOwnedEpisode(isOwnedEpisode)
+                .isRead(isRead)
+                .createdAt(convertedCreatedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
+++ b/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
@@ -16,6 +16,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -52,6 +55,9 @@ public class Episode extends Timestamped {
     @JoinColumn(name="novel_id")
     private Novel novel;
 
+    @OneToMany(mappedBy = "episode")
+    private List<OwnedEpisode> ownedEpisodes = new ArrayList<>();
+
     @Builder
     public Episode(Long id, String title, String content, Integer totalPageCount, Boolean isFree, Integer neededTicketCount, Float fileSize, Integer viewCount, Novel novel) {
 
@@ -81,5 +87,10 @@ public class Episode extends Timestamped {
     public void increaseViewCount(){
 
         this.viewCount++;
+    }
+
+    public void addOwnedEpisode(OwnedEpisode ownedEpisode){
+
+        ownedEpisodes.add(ownedEpisode);
     }
 }

--- a/src/main/java/com/numble/webnovelservice/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/numble/webnovelservice/episode/repository/EpisodeRepository.java
@@ -3,5 +3,10 @@ package com.numble.webnovelservice.episode.repository;
 import com.numble.webnovelservice.episode.entity.Episode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface EpisodeRepository extends JpaRepository<Episode, Long> {
+
+   Optional<List<Episode>> findByNovelId(Long novelId);
 }

--- a/src/main/java/com/numble/webnovelservice/episode/repository/OwnedEpisodeRepository.java
+++ b/src/main/java/com/numble/webnovelservice/episode/repository/OwnedEpisodeRepository.java
@@ -11,4 +11,6 @@ public interface OwnedEpisodeRepository extends JpaRepository<OwnedEpisode, Long
     Optional<OwnedEpisode> findByMemberIdAndEpisodeId(Long memberId, Long episodeId);
 
     List<OwnedEpisode> findByMemberId(Long id);
+
+    boolean existsByMemberIdAndEpisodeId(Long memberId, Long episodeId);
 }

--- a/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
+++ b/src/main/java/com/numble/webnovelservice/novel/controller/NovelController.java
@@ -3,11 +3,14 @@ package com.numble.webnovelservice.novel.controller;
 import com.numble.webnovelservice.common.response.ResponseMessage;
 import com.numble.webnovelservice.novel.dto.request.NovelRegisterRequest;
 import com.numble.webnovelservice.novel.dto.request.NovelUpdateInfoRequest;
+import com.numble.webnovelservice.novel.dto.response.NovelDetailsResponse;
 import com.numble.webnovelservice.novel.dto.response.NovelInfoResponseList;
 import com.numble.webnovelservice.novel.service.NovelService;
+import com.numble.webnovelservice.util.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,5 +74,13 @@ public class NovelController {
 
         NovelInfoResponseList response = novelService.retrieveLatestUpdateNovels();
         return new ResponseEntity<>(new ResponseMessage<>("최신 업데이트 소설 조회 성공", response), HttpStatus.OK);
+    }
+
+    @GetMapping("/{novelId}/details")
+    public ResponseEntity<ResponseMessage<NovelDetailsResponse>> retrieveNovelDetails(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                      @PathVariable Long novelId){
+
+        NovelDetailsResponse response = novelService.retrieveNovelDetails(userDetails.getMember(), novelId);
+        return new ResponseEntity<>(new ResponseMessage<>("소설 상세 조회 성공", response), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/numble/webnovelservice/novel/dto/response/NovelDetailsResponse.java
+++ b/src/main/java/com/numble/webnovelservice/novel/dto/response/NovelDetailsResponse.java
@@ -1,0 +1,89 @@
+package com.numble.webnovelservice.novel.dto.response;
+
+import com.numble.webnovelservice.episode.dto.response.EpisodeDetailsResponse;
+import com.numble.webnovelservice.episode.entity.Episode;
+import com.numble.webnovelservice.episode.entity.OwnedEpisode;
+import com.numble.webnovelservice.novel.entity.Genre;
+import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.entity.SerializedStatus;
+import com.numble.webnovelservice.util.time.TimeConverter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+public class NovelDetailsResponse {
+
+    private Long novelId;
+
+    private String title;
+
+    private String author;
+
+    private String genre;
+
+    private String coverImage;
+
+    private String serializedStatus;
+
+    private Integer likeCount;
+
+    private Integer totalViewCount;
+
+    private String updatedAt;
+
+    private List<EpisodeDetailsResponse> episodes;
+
+    @Builder
+    public NovelDetailsResponse(Long novelId, String title, String author, String genre, String coverImage, String serializedStatus, Integer likeCount, Integer totalViewCount, String updatedAt, List<EpisodeDetailsResponse> episodes) {
+
+        this.novelId = novelId;
+        this.title = title;
+        this.author = author;
+        this.genre = genre;
+        this.coverImage = coverImage;
+        this.serializedStatus = serializedStatus;
+        this.likeCount = likeCount;
+        this.totalViewCount = totalViewCount;
+        this.updatedAt = updatedAt;
+        this.episodes = episodes;
+    }
+
+    public static NovelDetailsResponse toResponse(Novel novel,
+                                                  List<Episode> episodes,
+                                                  List<OwnedEpisode> currentMemberOwnedNovelEpisodes) {
+
+        String koreanGenre = Genre.toKoreanName(novel.getGenre());
+        String koreanSerializedStatus = SerializedStatus.toKoreanName(novel.getSerializedStatus());
+        String convertedUpdatedAt = Optional.ofNullable(novel.getUpdatedAt())
+                .map(TimeConverter::toStringFormat)
+                .orElse(null);
+
+        List<EpisodeDetailsResponse> responseList = episodes.stream()
+                .map(episode -> EpisodeDetailsResponse.toResponse(
+                        episode,
+                        currentMemberOwnedNovelEpisodes.stream()
+                                .filter(Objects::nonNull)
+                                .filter(ownedEpisode -> ownedEpisode.getEpisode().getId().equals(episode.getId()))
+                                .findFirst()
+                                .orElse(null)))
+                .collect(Collectors.toList());
+
+        return NovelDetailsResponse.builder()
+                .novelId(novel.getId())
+                .title(novel.getTitle())
+                .author(novel.getAuthor())
+                .genre(koreanGenre)
+                .coverImage(novel.getCoverImage())
+                .serializedStatus(koreanSerializedStatus)
+                .likeCount(novel.getLikeCount())
+                .totalViewCount(novel.getTotalViewCount())
+                .updatedAt(convertedUpdatedAt)
+                .episodes(responseList)
+                .build();
+    }
+}


### PR DESCRIPTION
### 소설 상세 조회 기능 설명
소설을 조회할 때는 소설 정보와 에피소드 정보, 그리고 소장 에피소드(소장 여부와 읽음 여부)의 정보가 필요합니다.

**소장 에피소드의 정보**를 가져오는 과정에서 어려움을 겪었는데, 제가 생각한 방법은 세 가지가 있습니다.

 **`첫번째 방법`: 반복문에서 `OwnedEpisode ownedEpisode = findByMemberIdAndNovelId()`를 통해 소장 에피소드 객체 찾기**

- `Novel novel = novelRepository.findById(novelId);`: PathVariable로 받은 `novelId`로 소설 객체를 찾습니다.
- `List<Episode> episodes= episodeRepository.findByNovelId(novelId);`: PathVariable로 받은 `novelId`로 에피소드 객체 리스트를 찾습니다.
- `List<OwnedEpisode> currentMemberOwnedNovelEpisodes = new ArrayList<>();` **OwnedEpisode**가 담기는 새로운 `ArrayList`를 만듭니다.
  - 이 리스트는 찾은 소설의 각각의 에피소드에 대해 현재 멤버의 소장 에피소드를 담습니다. 값이 없을 경우 `null`을 담습니다.
- `for(Episode episode: episodes)`: episodes 리스트로 향상된 for문을 돌립니다.
  - `OwnedEpisode ownedEpisode = findByMemberIdAndNovelId()`: 현재 로그인한 멤버의 id와 에피소드의 id로 **OwnedEpisode** 객체를 찾습니다. 
    - 찾은 경우 리스트에 `ownedEpisode`를 `currentMemberOwnedNovelEpisodes` 리스트에 추가합니다.
  - episode의 `ownedEpisodes`가 `null `이거나, `ownedEpisodes`에 일치하는 **OwnedEpisode** 객체가 없는 경우 리스트에 `null`을 추가합니다.
- `return NovelDetailsResponse.toResponse(novel, episodes, currentMemberOwnedNovelEpisodes);`: Response를 생성하는 스태틱 메서드를 호출합니다.
</br>

 **`두번째 방법`: Episode와 OwnedEpisode를 양방향 연관관계를 맺어 반복문을 통해 객체 찾기**
- `Novel novel = novelRepository.findById(novelId);`: PathVariable로 받은 `novelId`로 소설 객체를 찾습니다.
- `List<Episode> episodes= episodeRepository.findByNovelId(novelId);`: PathVariable로 받은 `novelId`로 에피소드 객체 리스트를 찾습니다.
- `List<OwnedEpisode> currentMemberOwnedNovelEpisodes = new ArrayList<>();` **OwnedEpisode**가 담기는 새로운 `ArrayList`를 만듭니다.
  - 이 리스트는 찾은 소설의 각각의 에피소드에 대해 현재 멤버의 소장 에피소드를 담습니다. 값이 없을 경우 `null`을 담습니다.
- `for(Episode episode: episodes)`: episodes 리스트로 향상된 for문을 돌립니다.
  - `episode.getOwnedEpisodes()`를 반복문을 돌려 현재 로그인한 멤버의 id와 일치하는 **OwnedEpisode** 객체를 찾습니다. 
    - 찾은 경우 리스트에 `ownedEpisode`를 `currentMemberOwnedNovelEpisodes` 리스트에 추가합니다.
  - episode의 `ownedEpisodes`가 `null `이거나, `ownedEpisodes`에 일치하는 **OwnedEpisode** 객체가 없는 경우 리스트에 `null`을 추가합니다.
- `return NovelDetailsResponse.toResponse(novel, episodes, currentMemberOwnedNovelEpisodes);`: Response를 생성하는 스태틱 메서드를 호출합니다. 
</br>

**`세번째 방법`: Episode와 OwnedEpisode를 양방향 연관관계를 맺고,  `@Query`를 통해 찾기**
- 이 방법은 구체적인 구현은 해보지 않았지, 하나의 방법으로 염두해두었습니다.
- `List<Episode> findByNovelIdWithMemberOwnedEpisode(Long novelId, Long memberId)`: 에피소드 리스트를 찾는 JPA 문을 추가합니다. JPA문은 다음과 같이 작성될 것 같습니다.
  - `novelId`로 **Episode** 리스트를 찾는다.
  - **Episode**의 객체에 담긴 `ownedEpisodes`에서 멤버의 id를 갖고 있는 **OwnedEpisode** 객체가 있다면 커스텀으로 `OwnedEpisode ownedEpisode` 컬럼을 만들고 저장한다.
  - 없다면 **OwnedEpisode ownedEpisode**에 `null`을 넣는다.

### 방법에 대한 의사결정과정
각 소설이 가지고 있는 에피소드의 수는 1,000개라 가정합니다. (대부분 소설이 가지고 있는 에피소드(회차)는 1000개 이하입니다.)

**서비스 코드의 시간복잡도**

- 첫 번째 방법은 O(N) 입니다. (1,000)
- 두 번째 방법은 O(N*N) 입니다. (1,000,000)
- 세 번째 방법은 이 과정이 없습니다. (0)

**쿼리문의 시간 복잡도**
- 첫 번째 방법은 이 과정이 없습니다.
- 두 번째 방법은 O(N) 입니다. (1,000)
- 세 번째 방법은 O(N) 입니다. (1,000)

**쿼리문이 몇번 발생하는가?**

- 첫 번째 방법은 최대 N만큼 발생합니다. (현재 멤버가 소설의 모든 에피소드를 소장한 경우)
- 두 번째 방법은 1번 발생합니다.
- 세 번째 방법은 1번 발생합니다.

**종합 성능**

- 첫 번째 방법은 쿼리문이 N번 발생하므로 네트워크에 부담을 줄 수 있어 피해야 합니다.
- 두번째 방법은 시간 복잡도가 O(N*N)이지만 N이 1000이라고 가정 할 시에 나쁘지 않은 성능을 보여줍니다.
- 세번째 방법은 성능 상 제일 좋습니다. 

**의사 결정**

`트레이드 오프` -> 성능은 세 번째 방법이 제일 좋으나 두 번째 방법은 선택했습니다. 
이유는 다음과 같습니다.

- SQL문 작성 시 남이 이해하기 힘들다. 다음과 같은 과정이 있어 작성 시 이해하기 어려웠습니다. 
  - List인 `ownedEpisodes`에서 `memberId`와 일치하는 객체가 있다면 **OwnedEpisode**에 값을 넣는다.
  - 일치하는 객체가 없거나 `ownedEpisodes`가 `null`일 경우 **OwnedEpisode**에 `null`을 넣는다.

현재는 이해하기 쉽고 직관적인 자바 코드로 구현을 하였습니다. 
하지만, 추후 테스트 시 성능이 좋지 않게 나온다면 세번째 방법으로 리팩토링을 해야겠습니다.

### 소설 상세 조회 기능 작성

**NovelController 코드 작성**
- Controller 소설 상세 조회 기능 작성

**NovelService 코드 작성**
- Service 소설 상세 조회 기능 작성
- `getCurrentMemberOwnedNovelEpisodes(Member currentMember, List<Episode> episodes)` 메서드 설명
  - `episode`의 `ownedEpisodes `에 회원과 일치하는 `ownedEpisode `가 있다면, 리스트에 값을 넣는다.
  - `episode`의 `ownedEpisodes `가 `null `이거나 회원과 일치하는 `ownedEpisode `가 없다면, 리스트에 `null`을 넣는다.

`**NovelDetailsResponse 클래스 추가 및 코드 작성**
- 소설 상세 조회 시 응닶값인 response dto 입니다.
- OwnedEpisode 리스트가 null일 경우 null 처리를 하였습니다. 

**EpisodeDetailsResponse 클래스 추가 및 코드 작성**
- NovelDetailsResponse의 episodes의 응답값인 response dto 작성
- OwnedEpisode 객체가 null일 경우 null 처리를 하였습니다. 

### 소설 소장 시 양방향 연관관계 및 예외 처리 추가
**OwnedEpisodeService 코드 작성**
- 현재 멤버가 에피소드를 소장하고 있다면 예외를 반환하는 메서드 추가
```
    private void throwIfDuplicateOwnedEpisode(Long memberId, Long episodeId) {

        if(ownedEpisodeRepository.existsByMemberIdAndEpisodeId(memberId, episodeId)){
            throw new WebNovelServiceException(DUPLICATE_OWNED_EPISODE);
        }
    }
```
- `episode.addOwnedEpisode(ownedEpisode);`: 소설 소장 시 소설에 연관관계 추가

**Episode 엔티티 코드 작성**
- OwnedEpisode와 양방향 연관관계 설정 
```
    @OneToMany(mappedBy = "episode")
    private List<OwnedEpisode> ownedEpisodes = new ArrayList<>();
```
- `addOwnedEpisode()` 연관관계 추가 메서드 작성
