### PR TITLE
동시성 제어 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson:3.20.0'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/numble/webnovelservice/common/exception/ErrorCode.java
@@ -45,6 +45,8 @@ public enum ErrorCode {
     DUPLICATE_HOME_EXPOSURE(HttpStatus.BAD_REQUEST, "HOME_EXPOSURE_001", "이미 등록된 홈 노출입니다."),
     NOT_FOUND_HOME_EXPOSURE(HttpStatus.NOT_FOUND, "HOME_EXPOSURE_002", "찾을 수 없는 홈 노출입니다."),
     HOME_EXPOSURE_COUNT_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "HOME_EXPOSURE_003", "홈 노출 저장 범위를 벗어났습니다."),
+
+    NOT_AVAILABLE_LOCK(HttpStatus.CONFLICT, "CONCURRENCY_001", "락 획득이 불가능 합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/numble/webnovelservice/util/redis/config/LockRedisConfig.java
+++ b/src/main/java/com/numble/webnovelservice/util/redis/config/LockRedisConfig.java
@@ -1,0 +1,26 @@
+package com.numble.webnovelservice.util.redis.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class LockRedisConfig {
+    @Value("${spring.redisson.address}")
+    private String address;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redisson() {
+
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(address);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/numble/webnovelservice/util/redis/config/RedisConfig.java
+++ b/src/main/java/com/numble/webnovelservice/util/redis/config/RedisConfig.java
@@ -11,9 +11,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.redis.dailybest-host}")
     private String host;
-    @Value("${spring.redis.port}")
+    @Value("${spring.redis.dailybest-port}")
     private int port;
 
     @Bean


### PR DESCRIPTION
### 동시성 제어 코드 작성
결제 서비스 이용 시 동시성 제어 코드가 필요합니다.
저는 Redis가 지원하는 라이브러리인 Redisson을 선택하여 동시성 문제를 해결하였습니다.

**[LockRedisConfig](https://github.com/suhjaesuk/webnovelservice/blob/develop/src/main/java/com/numble/webnovelservice/util/redis/config/LockRedisConfig.java)** 클래스 추가 및 코드 작성
**[PointTransactionService](https://github.com/suhjaesuk/webnovelservice/blob/develop/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java)** 코드 작성
- `chargePoint`에 동시성 제어 코드 추가
```
    @Transactional
    public void chargePoint(Member currentMember, PointTransactionChargeRequest request) {
        // 락 이름 지정 및 락 생성
        String lockName = "charge-point" + " / " + "username: " + currentMember.getUsername();
        RLock lock = redissonClient.getLock(lockName);

        try {
            // 락 시간 설정
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);

            // 락이 안되있다면 예외 발생
            if (!isLocked) throw new WebNovelServiceException(NOT_AVAILABLE_LOCK);

            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
                    () -> new WebNovelServiceException(NOT_FOUND_MEMBER)
            );

            member.chargePoint(request.getAmount());

            PointTransaction pointTransaction = request.toPointTransaction(member);

            pointTransactionRepository.save(pointTransaction);

        // 락이 충돌할 경우 스레드 실행 중단
        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();

        } finally {
            lock.unlock();
        }
    }
```

**[TicketTransactionService](https://github.com/suhjaesuk/webnovelservice/blob/develop/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java)** 코드 작성
- `chargeTicket`에 동시성 제어 코드 추가
```
    @Transactional
    public void chargeTicket(Member currentMember, TicketTransactionChargeRequest request) {

        String lockName = "charge-ticket"+ " / " + "username: " + currentMember.getUsername();
        RLock lock = redissonClient.getLock(lockName);

        try {
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
            if (!isLocked) throw new WebNovelServiceException(NOT_AVAILABLE_LOCK);

            Member member = memberRepository.findById(currentMember.getId()).orElseThrow(
                    () -> new WebNovelServiceException(NOT_FOUND_MEMBER)
            );

            Integer ticketAmount = request.getAmount();
            Integer requiredPoint = ticketAmount * 100;
            Integer availablePoint = member.getPointAmount();

            throwIfInsufficientPoint(availablePoint, requiredPoint);

            member.chargeTicket(ticketAmount);

            TicketTransaction ticketTransaction = request.toTicketTransaction(member);

            ticketTransactionRepository.save(ticketTransaction);

            PointTransaction pointTransaction = request.toPointTransaction(member);

            pointTransactionRepository.save(pointTransaction);

            } catch (InterruptedException e) {
                Thread.currentThread().interrupt();

            } finally {
                lock.unlock();
        }
    }
```

**[OwnedEpisodeService](https://github.com/suhjaesuk/webnovelservice/blob/develop/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java)** 코드 작성
- `purchaseEpisode`에 동시성 제어 코드 추가
```
    @Transactional
    public void purchaseEpisode(Member currentMember, Long episodeId) {

        String lockName = "purchase-episode" + " / " + "username: " + currentMember.getUsername() + " / " + "episodeId: " + episodeId;
        RLock lock = redissonClient.getLock(lockName);

        try {
            boolean isLocked = lock.tryLock(2, 5, TimeUnit.SECONDS);
            if (!isLocked) throw new WebNovelServiceException(NOT_AVAILABLE_LOCK);

            throwIfDuplicateOwnedEpisode(currentMember.getId(), episodeId);

            Episode episode = episodeRepository.findById(episodeId).orElseThrow(
                    () -> new WebNovelServiceException(NOT_FOUND_EPISODE));

            int availableTickets = currentMember.getTicketCount();
            int requiredTickets = episode.getNeededTicketCount();

            throwIfInsufficientTicket(availableTickets, requiredTickets);
            currentMember.consumeTicket(requiredTickets);

            OwnedEpisode ownedEpisode = OwnedEpisode.createOwnedEpisode(currentMember, episode);
            PaymentType paymentType = getEpisodePaymentType(episode.getIsFree());
            TicketTransaction ticketTransaction = createConsumeTicketTransactionIfEpisodeIsPaid(currentMember, requiredTickets, paymentType);

            episode.addOwnedEpisode(ownedEpisode);

            ownedEpisodeRepository.save(ownedEpisode);
            saveTicketTransactionIfNotNull(ticketTransaction);

        } catch (InterruptedException e) {
            Thread.currentThread().interrupt();

        } finally {
            lock.unlock();
        }
    }
```

### 동시성 문제 해결법 종류 알아보기 
여러 사용자가 동시에 결제를 시도할 경우, 같은 결제 거래가 중복으로 발생할 수 있습니다. 이는 사용자에게 **큰 불편을 주고, 서비스의 신뢰도를 하락 시키는 큰 오류이기 때문에 꼭 해결해야 하는 문제**입니다. 

동시성 문제 해결 방법에는 여러가지 방법이 있습니다. 최근 서비스는 대규모 분산 시스템을 이용하므로 분산락을 구현해야 합니다. 따라서 **애플리케이션 내에서 처리하는 해결 방식은 적합하지 않다** 생각하였습니다. 다양한 분산락 방법이 있지만 이미 인프라가 구축되어 있는 **MySQL**과 **Redis**를 사용할 수 있습니다.

**[MySQL]**

**MySQL을 이용한 DB락**은 **낙관적 락, 비관적 락, 네임드 락**을 사용할 수 있습니다.

**낙관적 락**은 데이터를 변경할 때 데이터의 버전을 체크하여 변경 가능 여부를 판단하고, 변경 시 락을 거는 방식입니다. 락이 걸리지 않기 때문에 성능이 좋다는 장점이 있으나, 실패할 경우 로직을 개발자가 직접 만들어야하고, 동시에 같은 데이터를 변경할 경우 충돌이 발생합니다.

**비관적 락**은 데이터를 읽거나 변경할 때 락을 걸어 다른 사용자가 해당 데이터를 사용하지 못하도록 제어하는 방식입니다. 락을 걸어 충돌을 예방하기 때문에 데이터 정합성을 보장받을 수 있으나, 락을 걸면 성능이 저하됩니다.

**네임드 락**은 특정 이름을 가진 락을 생성하고, 해당 이름을 가진 락이 존재하는 경우에는 락 획득 전까지 다른 사용자가 접근하지 못하도록 제어하는 방식입니다. 독립적인 리소스에 락을 걸어 다른 리소스에 영향을 주지 않지만, 별도의 명령어로 해제/선점 시간이 끝나야 락이 해제됩니다. 이는 Connection Pool이 부족해질 수 있는 오류가 있습니다.

**[Redis]**

**Redis를 이용한 DB락**은 두가지 라이브러리인 **Lettuce**와 **Redisson**를 사용할 수 있습니다.

**Lettuce**는 Lock-Unlock 과정이 짧아서 락 하는 경우가 드문 경우에는 유용합니다. 하지만 타임 아웃이 지정되어 있지 않아 개발자가 직접 구현해야하고, 스핀락을 사용한 구현 기법으로 락을 획득하지 못한 경우 Redis에게 락을 획득하기 위해 계속 요청을 보내서 Redis에 부하가 발생할 수 있습니다.

**Redisson**은 Lock에 타임 아웃을 지정할 수 있어 무한정 대기 상태로 빠질 수 있는 위험이 없습니다. 또한 pub/sub 기능을 사용하여 Redis에 부하를 줄일 수 있습니다. 

**[Publish/Subscribe란]?**
- 특정한 주제(topic)에 대하여 topic을 구독한 모두에게 메세지를 발행하는 통신 방법
  -  채널을 구독한 수신자 모두에게 메세지를 전송하는 것을 의미

**[pub/sub 기능을 이용한 Redisson의 Lock 획득 프로세스]**
- tryLock을 호출하여 락 획득에 성공하면 True 반환
- pub/sub을 이용하여 메세지가 올 떄 까지 대기하다 락이 해제되었다는 메세지가 오면 대기를 풀고 다시 락 획득 시도
  - 락 획득에 실패하면 다시 락 해제 메세지를 기다림
  - 타임 아웃 시 까지 위 프로세스를 반복하다 타임아웃 시간이 지나면 최종적으로 false를 반환하고 락 획득에 실패했음을 알림 
 
**[트레이드오프]**

**Redis**는 인메모리 기반의 데이터베이스로 디스크 기반의 MySQL보다 빠른 속도를 지원합니다. **Redisson** 라이브러리를 사용하면 타임아웃 기능(TTL)을 활용하여 데드락을 방지할 수 있으며, pub/sub 기능으로 Redis에 부하를 줄이면서 동시성 제어를 수행할 수 있습니다.

이러한 이점들을 고려하여 Redisson을 이용하여 동시성 제어를 구현하였습니다.