### PR TITLE
Feature/fix concurrency

### DIFF
--- a/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
@@ -33,6 +33,7 @@ import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_NUMBER_
 import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_OUT_OF_BOUNDS;
 import static com.numble.webnovelservice.episode.entity.PaymentType.FREE;
 import static com.numble.webnovelservice.episode.entity.PaymentType.PAID;
+import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
 
 
 @Service
@@ -49,7 +50,7 @@ public class OwnedEpisodeService {
     @Transactional
     public void purchaseEpisode(Member currentMember, Long episodeId) {
 
-        String lockName = "purchase-episode" + " / " + "username: " + currentMember.getUsername() + " / " + "episodeId: " + episodeId;
+        String lockName = LOCK_NAME + currentMember.getId();
         RLock lock = redissonClient.getLock(lockName);
 
         try {

--- a/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
@@ -33,7 +33,7 @@ import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_NUMBER_
 import static com.numble.webnovelservice.common.exception.ErrorCode.PAGE_OUT_OF_BOUNDS;
 import static com.numble.webnovelservice.episode.entity.PaymentType.FREE;
 import static com.numble.webnovelservice.episode.entity.PaymentType.PAID;
-import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
+import static com.numble.webnovelservice.util.redis.config.LockRedisConfig.LOCK_NAME;
 
 
 @Service

--- a/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_AVAILABLE_LOCK;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
 
 
 @Service
@@ -41,7 +42,7 @@ public class PointTransactionService {
     @Transactional
     public void chargePoint(Member currentMember, PointTransactionChargeRequest request) {
 
-        String lockName = "charge-point" + " / " + "username: " + currentMember.getUsername();
+        String lockName = LOCK_NAME + currentMember.getId();
         RLock lock = redissonClient.getLock(lockName);
 
         try {

--- a/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/PointTransactionService.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_AVAILABLE_LOCK;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
-import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
+import static com.numble.webnovelservice.util.redis.config.LockRedisConfig.LOCK_NAME;
 
 
 @Service

--- a/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import static com.numble.webnovelservice.common.exception.ErrorCode.INSUFFICIENT_POINT;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_AVAILABLE_LOCK;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
-import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
+import static com.numble.webnovelservice.util.redis.config.LockRedisConfig.LOCK_NAME;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/service/TicketTransactionService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import static com.numble.webnovelservice.common.exception.ErrorCode.INSUFFICIENT_POINT;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_AVAILABLE_LOCK;
 import static com.numble.webnovelservice.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.numble.webnovelservice.util.redis.repository.DailyBestRedisRepository.LOCK_NAME;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +45,7 @@ public class TicketTransactionService {
     @Transactional
     public void chargeTicket(Member currentMember, TicketTransactionChargeRequest request) {
 
-        String lockName = "charge-ticket"+ " / " + "username: " + currentMember.getUsername();
+        String lockName = LOCK_NAME + currentMember.getId();
         RLock lock = redissonClient.getLock(lockName);
 
         try {

--- a/src/main/java/com/numble/webnovelservice/util/redis/config/LockRedisConfig.java
+++ b/src/main/java/com/numble/webnovelservice/util/redis/config/LockRedisConfig.java
@@ -13,6 +13,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 public class LockRedisConfig {
     @Value("${spring.redisson.address}")
     private String address;
+    public static final String LOCK_NAME = "memberId : ";
 
     @Bean(destroyMethod = "shutdown")
     public RedissonClient redisson() {

--- a/src/main/java/com/numble/webnovelservice/util/redis/repository/DailyBestRedisRepository.java
+++ b/src/main/java/com/numble/webnovelservice/util/redis/repository/DailyBestRedisRepository.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 public class DailyBestRedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
-    public static final String LOCK_NAME = "memberId : ";
 
     /**
      * @param novelId(Key)   소설의 제목

--- a/src/main/java/com/numble/webnovelservice/util/redis/repository/DailyBestRedisRepository.java
+++ b/src/main/java/com/numble/webnovelservice/util/redis/repository/DailyBestRedisRepository.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 public class DailyBestRedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    public static final String LOCK_NAME = "memberId : ";
 
     /**
      * @param novelId(Key)   소설의 제목


### PR DESCRIPTION
### 동시성 제어가 한 멤버에 대해서는 같은 락 이름으로 처리해야된다.

예를 들어 한 멤버가 포인트 충전과 티켓 구매가 동시에 이루어 졌다고 해보자. <br>
기존 포인트는 10000원, 기존 티켓은 100장이고, (티켓은 1장당 100포인트) <br>
충전 포인트는 10000원, 구매 티켓은 100장이다. <br> <br>

위와 같은 상황에서 동시성 제어를 안해줄 경우 아래와 같은 문제가 발생할 수 있다. 
- 포인트 충전, 티켓 구매 동시에 이루어질 경우
  - 총 포인트는 0원, 티켓은 200장

이러한 문제는 비즈니스 상 큰 오류이다. <br>
문제를 막기 위해 똑같은 멤버에 대한 동시성 제어를 진행해야 한다. <br>

LockRedisConfig에 LockName을 설명해주는 상수 추가
- `public static final String LOCK_NAME = "memberId : ";`

동시성 처리가 필요한 결제 관련 메서드에 락네임 수정
- `String lockName = LOCK_NAME + currentMember.getId();`