### PR TITLE
fix: 조회수 증가는 원자적으로 실행되어야 한다.

### DIFF
--- a/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
+++ b/src/main/java/com/numble/webnovelservice/episode/entity/Episode.java
@@ -85,11 +85,6 @@ public class Episode extends Timestamped {
         this.fileSize = request.getFileSize();
     }
 
-    public void increaseViewCount(){
-
-        this.viewCount++;
-    }
-
     public void addOwnedEpisode(OwnedEpisode ownedEpisode){
 
         ownedEpisodes.add(ownedEpisode);

--- a/src/main/java/com/numble/webnovelservice/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/numble/webnovelservice/episode/repository/EpisodeRepository.java
@@ -2,6 +2,7 @@ package com.numble.webnovelservice.episode.repository;
 
 import com.numble.webnovelservice.episode.entity.Episode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,8 @@ public interface EpisodeRepository extends JpaRepository<Episode, Long> {
 
    @Query("SELECT e FROM Episode e LEFT JOIN FETCH e.ownedEpisodes oe WHERE e.novel.id = :novelId")
    Optional<List<Episode>> findByNovelIdWithOwnedEpisodes(@Param("novelId") Long novelId);
+
+   @Modifying
+   @Query("UPDATE Episode e SET e.viewCount = e.viewCount + 1 WHERE e.id = :episodeId")
+   void increaseViewCountAtomically(@Param("episodeId") Long episodeId);
 }

--- a/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
+++ b/src/main/java/com/numble/webnovelservice/novel/entity/Novel.java
@@ -84,11 +84,6 @@ public class Novel extends Timestamped {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void increaseTotalViewCount(){
-
-        this.totalViewCount++;
-    }
-
     public void increaseLikeCount(){
 
         this.likeCount++;

--- a/src/main/java/com/numble/webnovelservice/novel/repository/NovelRepository.java
+++ b/src/main/java/com/numble/webnovelservice/novel/repository/NovelRepository.java
@@ -3,6 +3,9 @@ package com.numble.webnovelservice.novel.repository;
 import com.numble.webnovelservice.novel.entity.Genre;
 import com.numble.webnovelservice.novel.entity.Novel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,4 +18,8 @@ public interface NovelRepository extends JpaRepository<Novel, Long> {
     List<Novel> findByOrderByUpdatedAtDesc();
 
     List<Novel> findByIdIn(List<Long> novelId);
+
+    @Modifying
+    @Query("UPDATE Novel n SET n.totalViewCount = n.totalViewCount + 1 WHERE n.id = :novelId")
+    void increaseTotalViewCountAtomically(@Param("novelId") Long novelId);
 }

--- a/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
@@ -5,8 +5,8 @@ import com.numble.webnovelservice.episode.entity.Episode;
 import com.numble.webnovelservice.episode.entity.PaymentType;
 import com.numble.webnovelservice.episode.repository.EpisodeRepository;
 import com.numble.webnovelservice.member.entity.Member;
-import com.numble.webnovelservice.member.repository.MemberRepository;
 import com.numble.webnovelservice.novel.entity.Novel;
+import com.numble.webnovelservice.novel.repository.NovelRepository;
 import com.numble.webnovelservice.ownedepisode.dto.response.OwnedEpisodeInfoResponseList;
 import com.numble.webnovelservice.ownedepisode.dto.response.OwnedEpisodeReadResponse;
 import com.numble.webnovelservice.ownedepisode.entity.OwnedEpisode;
@@ -45,6 +45,7 @@ public class OwnedEpisodeService {
     private final TicketTransactionRepository ticketTransactionRepository;
     private final RedissonClient redissonClient;
     private final DailyBestRedisRepository dailyBestRedisRepository;
+    private final NovelRepository novelRepository;
 
     @Transactional
     public void purchaseEpisode(Member currentMember, Long episodeId) {
@@ -123,8 +124,8 @@ public class OwnedEpisodeService {
         Novel novel = episode.getNovel();
 
         ownedEpisode.markAsRead();
-        episode.increaseViewCount();
-        novel.increaseTotalViewCount();
+        episodeRepository.increaseViewCountAtomically(episode.getId());
+        novelRepository.increaseTotalViewCountAtomically(novel.getId());
 
         PaymentType payment = getEpisodePaymentType(episode.getIsFree());
         dailyBestRedisRepository.increaseDailyView(novel.getId().toString(), payment);


### PR DESCRIPTION
### 조회수 증가는 원자적으로 실행되어야 한다.
기존 객체의 필드를 UPDATE 하는경우 동시적으로 요청이 발생할경우 문제가 됩니다. <br>
예를들어, 기존 조회수가 100인 상태에서 동시에 2개의 요청이 들어올 경우
- 100 + 1, 100 + 1 이 되므로 102여야 하는 조회수가 101이 됩니다.
이러한 문제를 해결하기 위하여 동시성 제어 혹은 원자적 쿼리를 이용할 수 있습니다. <br>
이 문제는 다소 간단한 쿼리 메서드로 처리가 가능하기 때문에 원자적 쿼리를 이용하였습니다. <br> <br>

**Repository에 원자적 쿼리 메서드를 작성합니다.** 
- **EpisodeRepository 인터페이스**
```
   @Modifying
   @Query("UPDATE Episode e SET e.viewCount = e.viewCount + 1 WHERE e.id = :episodeId")
   void increaseViewCountAtomically(@Param("episodeId") Long episodeId);
```
- **NovelRepository 인터페이스**
```
    @Modifying
    @Query("UPDATE Novel n SET n.totalViewCount = n.totalViewCount + 1 WHERE n.id = :novelId")
    void increaseTotalViewCountAtomically(@Param("novelId") Long novelId);
```

**기존 메서드를 대체합니다..**
- `episode.increaseViewCount();` ->`episodeRepository.increaseViewCountAtomically(episode.getId());`
- `novel.increaseTotalViewCount(); `novelRepository.increaseTotalViewCountAtomically(novel.getId());`
