### PR TITLE
fix: 티켓과 에피소드는 연과관계를 맺어야 결제 정보를 명확하게 나타낸다.

### DIFF
--- a/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
+++ b/src/main/java/com/numble/webnovelservice/ownedepisode/service/OwnedEpisodeService.java
@@ -5,7 +5,6 @@ import com.numble.webnovelservice.episode.entity.Episode;
 import com.numble.webnovelservice.episode.entity.PaymentType;
 import com.numble.webnovelservice.episode.repository.EpisodeRepository;
 import com.numble.webnovelservice.member.entity.Member;
-import com.numble.webnovelservice.member.repository.MemberRepository;
 import com.numble.webnovelservice.novel.entity.Novel;
 import com.numble.webnovelservice.ownedepisode.dto.response.OwnedEpisodeInfoResponseList;
 import com.numble.webnovelservice.ownedepisode.dto.response.OwnedEpisodeReadResponse;
@@ -69,7 +68,7 @@ public class OwnedEpisodeService {
 
             OwnedEpisode ownedEpisode = OwnedEpisode.createOwnedEpisode(currentMember, episode);
             PaymentType paymentType = getEpisodePaymentType(episode.getIsFree());
-            TicketTransaction ticketTransaction = createConsumeTicketTransactionIfEpisodeIsPaid(currentMember, requiredTickets, paymentType);
+            TicketTransaction ticketTransaction = createConsumeTicketTransactionIfEpisodeIsPaid(currentMember, requiredTickets, paymentType, episode);
 
             episode.addOwnedEpisode(ownedEpisode);
 
@@ -91,10 +90,10 @@ public class OwnedEpisodeService {
         }
     }
 
-    private TicketTransaction createConsumeTicketTransactionIfEpisodeIsPaid(Member member, int requiredTickets, PaymentType paymentType) {
+    private TicketTransaction createConsumeTicketTransactionIfEpisodeIsPaid(Member member, int requiredTickets, PaymentType paymentType, Episode episode) {
 
         if(paymentType == PAID) {
-            return TicketTransaction.createConsumeTicketTransaction(member, requiredTickets);
+            return TicketTransaction.createConsumeTicketTransaction(member, requiredTickets, episode);
         }
         return null;
     }

--- a/src/main/java/com/numble/webnovelservice/transaction/entity/TicketTransaction.java
+++ b/src/main/java/com/numble/webnovelservice/transaction/entity/TicketTransaction.java
@@ -1,5 +1,6 @@
 package com.numble.webnovelservice.transaction.entity;
 
+import com.numble.webnovelservice.episode.entity.Episode;
 import com.numble.webnovelservice.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,9 +9,12 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import static com.numble.webnovelservice.transaction.entity.Type.CONSUME;
 
@@ -24,14 +28,19 @@ public class TicketTransaction extends Transaction{
     @Column(name="ticket_transaction_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="episode_id")
+    private Episode episode;
+
     @Builder
-    public TicketTransaction(Type type, Integer amount, Integer balance, Member member, Long id) {
+    public TicketTransaction(Type type, Integer amount, Integer balance, Member member, Long id, Episode episode) {
         super(type, amount, balance, member);
         this.id = id;
+        this.episode = episode;
     }
 
 
-    public static TicketTransaction createConsumeTicketTransaction(Member member, int amount) {
+    public static TicketTransaction createConsumeTicketTransaction(Member member, int amount, Episode episode) {
 
         Type type = CONSUME;
         Integer balance = member.getTicketCount() - amount;
@@ -41,6 +50,7 @@ public class TicketTransaction extends Transaction{
                                 .amount(amount)
                                 .balance(balance)
                                 .member(member)
+                                .episode(episode)
                                 .build();
     }
 }


### PR DESCRIPTION
### 티켓과 에피소드는 연과관계를 맺어야 결제 정보를 명확하게 나타낸다.
기존의 설계는 티켓의 소모 정보만 나타냈는데, 
이는 비즈니스에서 `이 티켓을 무엇에 썼는지 알 수 없다.` 라는 모호한 점이 있습니다.
- 따라서 연관관계를 맺어 티켓을 소모(에피소드 구매)할 경우 구매한 에피소드를 저장합니다.
- 단, 티켓을 충전 할 경우 TicketTransaction 테이블의 episodeId 값은 NULL 입니다. 